### PR TITLE
Fix empty reading list return value

### DIFF
--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -91,8 +91,9 @@ export const getUserReadingList = async (userId: string) => {
       .collection(COLLECTIONS.READING_LISTS)
       .doc(userId)
       .get();
-    
-    return doc.exists ? doc.data().books : [];
+
+    const data = doc.data();
+    return doc.exists ? data?.books || [] : [];
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
## Summary
- ensure `getUserReadingList` always returns an array even when the doc has no books

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c81bb67c8323883c559df3483607