### PR TITLE
Update security rules for reading lists

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -10,7 +10,7 @@ service cloud.firestore {
     // Reading lists - accessible by authenticated users
     match /readingLists/{listId} {
       allow read: if request.auth != null;
-      allow write: if request.auth != null && request.auth.uid == resource.data.userId;
+      allow write: if request.auth != null && request.auth.uid == listId;
     }
     
     // Reviews - public read, authenticated write


### PR DESCRIPTION
## Summary
- update Firestore security rule to ensure writing a reading list can only be done by the user matching the list ID

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9c5adc08323b0391bde3e9f1d1b

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the security rules for the `/readingLists/{listId}` path to allow writing only if the authenticated user ID matches the list ID.

### Why are these changes being made?

The change ensures that only the user associated with a particular reading list (identified by the list ID) is allowed to write to it, enhancing the security model by tying write permissions directly to the list ownership. This addresses potential security loopholes where users might access or modify other users' reading lists if only verifying against a stored `userId`.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->