### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@ We love your input! We want to make contributing to Book Review App as easy and 
 - Proposing new features
 - Becoming a maintainer
 
-## We Develop with Github
-We use Github to host code, to track issues and feature requests, as well as accept pull requests.
+## We Develop with GitHub
+We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
 
-## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html)
+## We Use [GitHub Flow](https://guides.github.com/introduction/flow/index.html)
 Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
 
 1. Fork the repo and create your branch from `main`.
@@ -24,7 +24,7 @@ Pull requests are the best way to propose changes to the codebase. We actively w
 ## Any contributions you make will be under the MIT Software License
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report bugs using Github's [issue tracker](https://github.com/vgcman16/BookReviewApp/issues)
+## Report bugs using GitHub's [issue tracker](https://github.com/vgcman16/BookReviewApp/issues)
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/vgcman16/BookReviewApp/issues/new/choose).
 
 ## Write bug reports with detail, background, and sample code


### PR DESCRIPTION
## Summary
- fix capitalization of GitHub references in CONTRIBUTING

## Testing
- `npm install`
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9c49b208323bf1f8380559cee13