### PR TITLE
Fix Jest act warning

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -24,9 +24,12 @@ import App from '../App';
 import {it} from '@jest/globals';
 
 // Note: test renderer must be required after react-native.
-import renderer from 'react-test-renderer';
+import renderer, {act} from 'react-test-renderer';
 
-it('renders correctly', () => {
-  const tree = renderer.create(<App />);
-  expect(tree.toJSON()).toMatchSnapshot();
+it('renders correctly', async () => {
+  let tree;
+  await act(async () => {
+    tree = renderer.create(<App />);
+  });
+  expect(tree!.toJSON()).toMatchSnapshot();
 });


### PR DESCRIPTION
## Summary
- use `act` when rendering `App` in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841d6c51bdc8323818f7c16c7517db4