### PR TITLE
Add eslint.config.js

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,28 @@
+import js from '@eslint/js';
+import { FlatCompat } from '@eslint/eslintrc';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rnPath = dirname(require.resolve('@react-native/eslint-config/package.json'));
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  resolvePluginsRelativeTo: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+
+export default [
+  ...compat.config({
+    overrides: [
+      {
+        files: ['**/*.ts', '**/*.tsx'],
+        parserOptions: { ecmaVersion: 'latest' },
+        extends: ['@react-native'],
+      },
+    ],
+  }),
+];


### PR DESCRIPTION
## Summary
- add ESLint flat config using `@react-native` rules

## Testing
- `npm run lint` *(fails: Could not find rule "@typescript-eslint/func-call-spacing")*

------
https://chatgpt.com/codex/tasks/task_e_6841d6c432808323bf218e68e3a53e46

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new `eslint.config.js` file to configure ESLint settings, including support for TypeScript and React Native.

### Why are these changes being made?

This change introduces a standardized ESLint configuration for the project, aimed at improving code quality and consistency. By incorporating `@eslint/js`, `@react-native/eslint-config`, and setting the appropriate parser options, this ensures proper linting for both JavaScript and TypeScript files within a React Native environment.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->