### PR TITLE
Check userId before Firebase calls

### DIFF
--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -40,6 +40,10 @@ const BookDetailScreen = ({ route, navigation }) => {
   const checkReadingList = async () => {
     try {
       const userId = auth().currentUser?.uid;
+      if (!userId) {
+        navigation.replace('Auth');
+        return;
+      }
       const readingListDoc = await firestore()
         .collection('readingLists')
         .doc(userId)
@@ -55,6 +59,10 @@ const BookDetailScreen = ({ route, navigation }) => {
   const submitReview = async () => {
     try {
       const userId = auth().currentUser?.uid;
+      if (!userId) {
+        navigation.replace('Auth');
+        return;
+      }
       await firestore().collection('reviews').add({
         bookId: book.id,
         userId,
@@ -75,6 +83,10 @@ const BookDetailScreen = ({ route, navigation }) => {
   const toggleReadingList = async () => {
     try {
       const userId = auth().currentUser?.uid;
+      if (!userId) {
+        navigation.replace('Auth');
+        return;
+      }
       const readingListRef = firestore().collection('readingLists').doc(userId);
       
       if (isInReadingList) {

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -22,7 +22,11 @@ const ProfileScreen = ({ navigation }) => {
   const fetchUserData = async () => {
     try {
       const userId = auth().currentUser?.uid;
-      
+      if (!userId) {
+        navigation.replace('Auth');
+        return;
+      }
+
       // Fetch user's reviews
       const reviewsSnapshot = await firestore()
         .collection('reviews')

--- a/src/screens/ReadingListScreen.tsx
+++ b/src/screens/ReadingListScreen.tsx
@@ -21,6 +21,10 @@ const ReadingListScreen = ({ navigation }) => {
   const fetchReadingList = async () => {
     try {
       const userId = auth().currentUser?.uid;
+      if (!userId) {
+        navigation.replace('Auth');
+        return;
+      }
       const readingListDoc = await firestore()
         .collection('readingLists')
         .doc(userId)
@@ -49,6 +53,10 @@ const ReadingListScreen = ({ navigation }) => {
   const removeFromReadingList = async (bookId) => {
     try {
       const userId = auth().currentUser?.uid;
+      if (!userId) {
+        navigation.replace('Auth');
+        return;
+      }
       await firestore()
         .collection('readingLists')
         .doc(userId)


### PR DESCRIPTION
## Summary
- check if `auth().currentUser?.uid` exists in BookDetail, Profile, and ReadingList screens
- redirect to Auth screen when no user is logged in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e02c4950832381b29c08c92d51b2

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add checks for `userId` presence before making Firebase Firestore calls and redirect to 'Auth' screen if `userId` is not present.

### Why are these changes being made?

This change ensures that Firebase Firestore operations are safely handled only when a user is authenticated, preventing unauthorized access or errors that might occur when `userId` is undefined. Automatically redirecting unauthenticated users to the 'Auth' screen helps maintain a secure and logical flow within the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->