### PR TITLE
Remove deprecated mongoose connection options

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -14,14 +14,12 @@ app.use(cors());
 app.use(bodyParser.json());
 
 // MongoDB Connection
-mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/bookreview', {
-  useNewUrlParser: true,
-  useUnifiedTopology: true
-}).then(() => {
-  console.log('Connected to MongoDB');
-}).catch((err) => {
-  console.error('MongoDB connection error:', err);
-});
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/bookreview')
+  .then(() => {
+    console.log('Connected to MongoDB');
+  }).catch((err) => {
+    console.error('MongoDB connection error:', err);
+  });
 
 // Book Schema
 const bookSchema = new mongoose.Schema({


### PR DESCRIPTION
## Summary
- use default connection options in `backend/server.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e02b5a208323ad73027eed20ace7

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove deprecated mongoose connection options `useNewUrlParser` and `useUnifiedTopology` from the MongoDB connection in `server.js`.

### Why are these changes being made?

These options have been set as defaults in recent versions of mongoose, making their explicit declaration redundant. Removing them simplifies the code and future-proofs the connection configuration.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->