### PR TITLE
Fix BookDetailScreen map closing syntax

### DIFF
--- a/src/screens/BookDetailScreen.tsx
+++ b/src/screens/BookDetailScreen.tsx
@@ -135,7 +135,8 @@ const BookDetailScreen = ({ route, navigation }) => {
                 color="#FFD700"
               />
             </TouchableOpacity>
-          ))}
+          ))
+        }
         </View>
         <TextInput
           style={styles.reviewInput}
@@ -163,7 +164,8 @@ const BookDetailScreen = ({ route, navigation }) => {
             </View>
             <Text style={styles.reviewText}>{review.review}</Text>
           </View>
-        ))}
+        ))
+      }
       </View>
     </ScrollView>
   );


### PR DESCRIPTION
## Summary
- fix BookDetailScreen JSX loops by moving closing braces to their own lines

## Testing
- `npm test`
- `npx tsc --noEmit -p tsconfig.json` *(fails: could not find declaration files)*

------
https://chatgpt.com/codex/tasks/task_e_6841e02a31f48323b8afc509adcb670e

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the closing syntax of the `.map` function in the `BookDetailScreen.tsx` to ensure proper JSX structure.

### Why are these changes being made?

The change addresses syntax issues that were causing rendering problems in the `BookDetailScreen` component by ensuring the `map` function's closing parentheses and brackets are correctly placed to establish valid JSX syntax, thus preventing potential runtime errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->